### PR TITLE
Update docstring for detect.py

### DIFF
--- a/rootpath/detect.py
+++ b/rootpath/detect.py
@@ -31,7 +31,7 @@ def detect(current_path = None, pattern = None):
 
     Examples:
 
-        from rootpath import rootpath
+        import rootpath
 
         rootpath.detect()
         rootpath.detect(__file__)


### PR DESCRIPTION
`from rootpath import rootpath` does not work - updated docs to reflect this.