### PR TITLE
Added Change Root Detection Pattern Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,18 @@ SAY: /home/me/projects/py-foo
 ---
 ```
 
+## Change Root Detection Pattern
+As stated earlier, the detection of the package/project's root directory
+is done by searching for typical package files (e.g. `.git`,
+`requirements.txt`, etc.).
+
+To override this behavior and have `rootpath` use a different file for
+root detection, set the `pattern` kwarg to the desired filename.
+
+### Example: Pipfile Root Detection
+```
+rootpath(pattern='Pipfile')
+```
 
 ## About
 


### PR DESCRIPTION
Showing users how to use the pattern kwarg for the rootpath.detect
method. Also added an example: the pattern argument for using a Pipfile
as the detection pattern.

More examples of the usage of the `pattern` argument can be added.