### PR TITLE
removed addition of None to sys.path in case there is no project root

### DIFF
--- a/rootpath/append.py
+++ b/rootpath/append.py
@@ -44,6 +44,11 @@ def append(current_path = None, pattern = None):
     """
     project_root_path = rootpath.detect(current_path, pattern)
 
+    # if the returned value is None it should not be added
+
+    if project_root_path is None:
+        return False, project_root_path
+
     try:
         if project_root_path != current_path:
             try:


### PR DESCRIPTION
If the project does not have a rootpath None is added to sys.path. This has been fixed.